### PR TITLE
improve key deletion and add helper functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.sw*

--- a/store.go
+++ b/store.go
@@ -41,6 +41,7 @@ func New() Store {
 		"getrx":  s.GetAllRegexp,
 		"group":  s.Group,
 		"select": s.Select,
+		"hash":   s.Hash,
 		"take":   s.Take,
 		"keys":   s.Keys,
 		"values": s.Values,
@@ -236,6 +237,18 @@ func (s Store) Group(ks KVPairs, pattern string) map[string]KVPairs {
 	}
 	for group, _ := range result {
 		sort.Sort(result[group])
+	}
+	return result
+}
+
+func (s Store) Hash(ks KVPairs, pattern string) map[string]string {
+	re := regexp.MustCompile(pattern)
+	result := make(map[string]string)
+	for _, kv := range ks {
+		match := re.FindStringSubmatch(kv.Key)
+		if len(match) >= 1 {
+			result[match[1]] = kv.Value
+		}
 	}
 	return result
 }


### PR DESCRIPTION
Helper functions added to allow grouping, selection and parsing of KVPairs.

As an example, [here](https://gist.github.com/psev/41c0415b626a4360bfed) is a dynamic nginx configuration template which has been verified to work with [atomd](https://github.com/psev/atomd) and most likely works with confd.

The deletion functions now allow the deletion of entire directories.