### PR TITLE
fix bug of List: when has same prefix, list return partial path

### DIFF
--- a/store.go
+++ b/store.go
@@ -121,12 +121,14 @@ func (s Store) List(filePath string) []string {
 	m := make(map[string]bool)
 	s.RLock()
 	defer s.RUnlock()
+	prefix := pathToTerms(path.Clean(filePath))
 	for _, kv := range s.m {
 		if kv.Key == filePath {
 			m[path.Base(kv.Key)] = true
 			continue
 		}
-		if strings.HasPrefix(kv.Key, filePath) {
+		target := pathToTerms(path.Dir(kv.Key))
+		if samePrefixTerms(target, prefix) {
 			m[strings.Split(stripKey(kv.Key, filePath), "/")[0]] = true
 		}
 	}
@@ -175,4 +177,21 @@ func (s Store) Purge() {
 
 func stripKey(key, prefix string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/")
+}
+
+func pathToTerms(filePath string) []string {
+	return strings.Split(path.Clean(filePath), "/")
+}
+
+func samePrefixTerms(left, right []string) bool {
+	l := len(left)
+	if len(left) > len(right) {
+		l = len(right)
+	}
+	for i := 0; i < l; i++ {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/store_test.go
+++ b/store_test.go
@@ -126,6 +126,10 @@ var listTestMap = map[string]string{
 	"/deis/services/srv1/node3":      "10.244.1.3:80",
 	"/deis/services/srv2/node1":      "10.244.2.1:80",
 	"/deis/services/srv2/node2":      "10.244.2.2:80",
+	"/deis/prefix/node1":             "prefix_node1",
+	"/deis/prefix/node2":             "prefix_node2",
+	"/deis/prefix_a/node3":           "prefix_a_node3",
+	"/deis/prefixb/node4":            "prefixb_node4",
 }
 
 func TestList(t *testing.T) {
@@ -137,6 +141,23 @@ func TestList(t *testing.T) {
 	paths := []string{
 		"/deis/services",
 		"/deis/services/",
+	}
+	for _, filePath := range paths {
+		got := s.List(filePath)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("List(%s) = %v, want %v", filePath, got, want)
+		}
+	}
+}
+
+func TestListForSamePrefix(t *testing.T) {
+	s := New()
+	for k, v := range listTestMap {
+		s.Set(k, v)
+	}
+	want := []string{"node1", "node2"}
+	paths := []string{
+		"/deis/prefix",
 	}
 	for _, filePath := range paths {
 		got := s.List(filePath)


### PR DESCRIPTION
fix the bug like this: 

/a/bb
/aa/bb

if I use "ls /a", I got "bb", "a" return.