### PR TITLE
add GetAllRecursive

### DIFF
--- a/kvpair.go
+++ b/kvpair.go
@@ -1,5 +1,7 @@
 package memkv
 
+import "strings"
+
 type KVPair struct {
 	Key   string
 	Value string
@@ -16,5 +18,26 @@ func (ks KVPairs) Less(i, j int) bool {
 }
 
 func (ks KVPairs) Swap(i, j int) {
+	ks[i], ks[j] = ks[j], ks[i]
+}
+
+func (kv KVPair) Depth() int {
+	return strings.Count(kv.Key, "/")
+}
+
+type DepthSortedKVPairs []KVPair
+
+func (ks DepthSortedKVPairs) Len() int {
+	return len(ks)
+}
+
+func (ks DepthSortedKVPairs) Less(i, j int) bool {
+	if ks[i].Depth() == ks[j].Depth() {
+		return ks[i].Key < ks[j].Key
+	}
+	return ks[i].Depth() < ks[j].Depth()
+}
+
+func (ks DepthSortedKVPairs) Swap(i, j int) {
 	ks[i], ks[j] = ks[j], ks[i]
 }

--- a/store.go
+++ b/store.go
@@ -45,6 +45,7 @@ func New() Store {
 		"gets":   s.GetAll,
 		"getv":   s.GetValue,
 		"getvs":  s.GetAllValues,
+		"getr":   s.GetAllRecursive,
 	}
 	return s
 }
@@ -114,6 +115,25 @@ func (s Store) GetAll(pattern string) (KVPairs, error) {
 		return ks, nil
 	}
 	sort.Sort(ks)
+	return ks, nil
+}
+
+// GetAllRecursive returns a KVPair for all nodes recursive with keys starting
+// with prefix.
+func (s Store) GetAllRecursive(prefix string) (KVPairs, error) {
+	ks := make(KVPairs, 0)
+	s.RLock()
+	defer s.RUnlock()
+	for _, kv := range s.m {
+		m := strings.HasPrefix(kv.Key, prefix)
+		if m {
+			ks = append(ks, kv)
+		}
+	}
+	if len(ks) == 0 {
+		return ks, nil
+	}
+	sort.Sort(sort.Reverse(DepthSortedKVPairs(ks)))
 	return ks, nil
 }
 


### PR DESCRIPTION
GetAllRecursive gets all keys with a specific prefix from etcd.

When using a nested structure in etcd like this:
```
/services/www/example.com/beta/container
/services/www/example.com/container
```

This function will return the deepest entry first. Which is required when creating acl's in HAproxy with confd.
