### PR TITLE
Fix List command to properly return only subkeys

### DIFF
--- a/store.go
+++ b/store.go
@@ -133,20 +133,19 @@ func (s Store) GetAllValues(pattern string) ([]string, error) {
 	return vs, nil
 }
 
+// Returns all subkeys, []string, where path matches its 
+// argument. Returns an empty list if path is not found.
 func (s Store) List(filePath string) []string {
 	vs := make([]string, 0)
 	m := make(map[string]bool)
 	s.RLock()
 	defer s.RUnlock()
-	prefix := pathToTerms(path.Clean(filePath))
+	prefix := path.Clean(filePath)
 	for _, kv := range s.m {
-		if kv.Key == filePath {
+		target := path.Dir(kv.Key)
+
+		if(target == prefix){
 			m[path.Base(kv.Key)] = true
-			continue
-		}
-		target := pathToTerms(path.Dir(kv.Key))
-		if samePrefixTerms(target, prefix) {
-			m[strings.Split(stripKey(kv.Key, filePath), "/")[0]] = true
 		}
 	}
 	for k := range m {


### PR DESCRIPTION
I actually encountered this issue when using confd (which depends on this) with etcd as a backend. Since etcd flattens directories, you can end up with a number of keys that are a section of a potentially deeper path. The behavior I was expecting was based off the etcd documentation for `list` since I couldnt find anything in this repo, so hopefully this is correct:

> Returns all subkeys, []string, where path matches its argument. Returns an empty list if path is not found.

Given the keys (like how etcd would structure them):

```
/services
/services/test-service
/services/test-service/nodes
/services/test-service/nodes/node-1
/services/test-service/nodes/node-2
```

Before this change, if I tried to list all of the keys in the `/services/test-service/nodes` directory, I would get a list with two items - `["node-1", "services"]`  when I would expect the output to be: `["node-1", "node-2"]` as they are located in the `/services/test-service/nodes` path.

Example program I used to test this change:

``` go
package main

import (
    "fmt"
    "github.com/seanmcgary/memkv"
)

func main() {
    s := memkv.New()

    s.Set("/services", "")
    s.Set("/services/test-service", "")
    s.Set("/services/test-service/nodes", "")
    s.Set("/services/test-service/nodes/node-1", "some node 1")
    s.Set("/services/test-service/nodes/node-2", "some node 2")

    key1 := "/services/test-service/nodes"
    result := s.List(key1)
    fmt.Printf("%s --> %s - valid? %t\n", key1, result, len(result) == 2)

    s2 := memkv.New()
    s2.Set("/services/test-service/nodes/node-1", "some node 1")
    s2.Set("/services/test-service/nodes/node-2", "some node 2")

    key2 := "/services/test-service/nodes"
    result = s2.List(key2)
    fmt.Printf("%s --> %s - valid? %t\n", key2, result, len(result) == 2)

    key3 := "/services/test-service"
    result = s2.List(key3)
    fmt.Printf("%s --> %s - valid? %t\n", key3, result, len(result) == 0)
}
```

```
/services/test-service/nodes --> [node-1 node-2] - valid? true
/services/test-service/nodes --> [node-1 node-2] - valid? true
/services/test-service --> [] - valid? true
```
