### PR TITLE
Fix 'ls' function when path contains no subkeys

### DIFF
--- a/store.go
+++ b/store.go
@@ -138,14 +138,14 @@ func (s Store) List(filePath string) []string {
 	m := make(map[string]bool)
 	s.RLock()
 	defer s.RUnlock()
-	prefix := pathToTerms(path.Clean(filePath))
+	prefix := pathToTerms(filePath)
 	for _, kv := range s.m {
 		if kv.Key == filePath {
 			m[path.Base(kv.Key)] = true
 			continue
 		}
 		target := pathToTerms(path.Dir(kv.Key))
-		if samePrefixTerms(target, prefix) {
+		if samePrefixTerms(prefix, target) {
 			m[strings.Split(stripKey(kv.Key, filePath), "/")[0]] = true
 		}
 	}
@@ -200,13 +200,12 @@ func pathToTerms(filePath string) []string {
 	return strings.Split(path.Clean(filePath), "/")
 }
 
-func samePrefixTerms(left, right []string) bool {
-	l := len(left)
-	if len(left) > len(right) {
-		l = len(right)
+func samePrefixTerms(prefix, test []string) bool {
+	if len(test) < len(prefix) {
+		return false
 	}
-	for i := 0; i < l; i++ {
-		if left[i] != right[i] {
+	for i := 0; i < len(prefix); i++ {
+		if prefix[i] != test[i] {
 			return false
 		}
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -226,7 +226,7 @@ func TestListEmptyChildrenTrailingSlash(t *testing.T) {
 	s := New()
 	s.Set("/top/first", "")
 	s.Set("/top/second", "")
-	s.Set("/misc", "")
+
 	want := []string{}
 	paths := []string{"/top/first/", "/top/second/"}
 	for _, filePath := range paths {
@@ -241,13 +241,12 @@ func TestListEmptyChildren(t *testing.T) {
 	s := New()
 	s.Set("/top/first", "")
 	s.Set("/top/second", "")
-	s.Set("/misc", "")
-	
+
 	first := s.List("/top/first")
 	if !reflect.DeepEqual(first, []string{"first"}) {
 		t.Errorf("List(/top/first) = %v, want [first]", first)
 	}
-	
+
 	second := s.List("/top/second")
 	if !reflect.DeepEqual(second, []string{"second"}) {
 		t.Errorf("List(/top/second) = %v, want [second]", second)

--- a/store_test.go
+++ b/store_test.go
@@ -222,6 +222,38 @@ func TestListForFile(t *testing.T) {
 	}
 }
 
+func TestListEmptyChildrenTrailingSlash(t *testing.T) {
+	s := New()
+	s.Set("/top/first", "")
+	s.Set("/top/second", "")
+	s.Set("/misc", "")
+	want := []string{}
+	paths := []string{"/top/first/", "/top/second/"}
+	for _, filePath := range paths {
+		got := s.List(filePath)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("List(%s) = %v, want %v", filePath, got, want)
+		}
+	}
+}
+
+func TestListEmptyChildren(t *testing.T) {
+	s := New()
+	s.Set("/top/first", "")
+	s.Set("/top/second", "")
+	s.Set("/misc", "")
+	
+	first := s.List("/top/first")
+	if !reflect.DeepEqual(first, []string{"first"}) {
+		t.Errorf("List(/top/first) = %v, want [first]", first)
+	}
+	
+	second := s.List("/top/second")
+	if !reflect.DeepEqual(second, []string{"second"}) {
+		t.Errorf("List(/top/second) = %v, want [second]", second)
+	}
+}
+
 func TestListDir(t *testing.T) {
 	s := New()
 	for k, v := range listTestMap {


### PR DESCRIPTION
This is meant as an alternative fix to #11 as I ran into new issues when attempting to use that patch.  This ought to fix kelseyhightower/confd#430 as well.  At least, I've tested this with zookeeper.
