### PR TITLE
Fix List if leaf and dir nodes are mixed

### DIFF
--- a/store.go
+++ b/store.go
@@ -145,7 +145,7 @@ func (s Store) List(filePath string) []string {
 			continue
 		}
 		target := pathToTerms(path.Dir(kv.Key))
-		if samePrefixTerms(target, prefix) {
+		if len(target) >= len(prefix) && samePrefixTerms(target, prefix) {
 			m[strings.Split(stripKey(kv.Key, filePath), "/")[0]] = true
 		}
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -164,6 +164,8 @@ var listTestMap = map[string]string{
 	"/deis/services/srv2/node2":       "10.244.2.2:80",
 	"/deis/prefix/node1":              "prefix_node1",
 	"/deis/prefix/node2/leafnode":     "prefix_node2",
+	"/deis/prefix/node2/sub1/leaf1":   "prefix_node2_sub1_leaf1",
+	"/deis/prefix/node2/sub1/leaf2":   "prefix_node2_sub1_leaf2",
 	"/deis/prefix/node3/leafnode":     "prefix_node3",
 	"/deis/prefix_a/node4":            "prefix_a_node4",
 	"/deis/prefixb/node5/leafnode":    "prefixb_node5",
@@ -217,6 +219,18 @@ func TestListForFile(t *testing.T) {
 	}
 	want := []string{"key"}
 	got := s.List("/deis/services/key")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("List(%s) = %v, want %v", "/deis/services", got, want)
+	}
+}
+
+func TestListForMixedLeafSubnodes(t *testing.T) {
+	s := New()
+	for k, v := range listTestMap {
+		s.Set(k, v)
+	}
+	want := []string{"leaf1", "leaf2"}
+	got := s.List("/deis/prefix/node2/sub1")
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("List(%s) = %v, want %v", "/deis/services", got, want)
 	}


### PR DESCRIPTION
List gets mixed-up if a leaf node and a dir node has the same prefix.

Added the necessary condition and extended the tests to demonstrate the error.

Note: I found this using "confd" with etcd backend were the "ls" function produced a rather unexpected result
