### PR TITLE
Fix getv with empty default value

### DIFF
--- a/store.go
+++ b/store.go
@@ -80,15 +80,11 @@ func (s Store) Get(key string) (KVPair, error) {
 // GetValue gets the value associated with key. If there are no values
 // associated with key, GetValue returns "", ErrNotExist.
 func (s Store) GetValue(key string, v ...string) (string, error) {
-	defaultValue := ""
-	if len(v) > 0 {
-		defaultValue = v[0]
-	}
-
 	kv, err := s.Get(key)
 	if err != nil {
-		if defaultValue != "" {
-			return defaultValue, nil
+		if len(v) > 0 {
+			// Take default
+			return v[0], nil
 		}
 		return "", err
 	}

--- a/store_test.go
+++ b/store_test.go
@@ -66,6 +66,18 @@ func TestGetValueWithDefault(t *testing.T) {
 	}
 }
 
+func TestGetValueWithEmptyDefault(t *testing.T) {
+	want := ""
+	s := New()
+	got, err := s.GetValue("/db/user", "")
+	if err != nil {
+		t.Errorf("Unexpected error", err.Error())
+	}
+	if got != want {
+		t.Errorf("want %v, got %v", want, got)
+	}
+}
+
 var getalltestinput = map[string]string{
 	"/app/db/pass":               "foo",
 	"/app/db/user":               "admin",


### PR DESCRIPTION
The getv template function fails with an error if: the supplied key doesn't exist and the default value argument is an empty string.  This makes some templates awkward, where I *really do* want an empty string as the default.

Fixes kelseyhightower/confd#584