### PR TITLE
Fix missing string format directive

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -59,7 +59,7 @@ func TestGetValueWithDefault(t *testing.T) {
 	s := New()
 	got, err := s.GetValue("/db/user", "defaultValue")
 	if err != nil {
-		t.Errorf("Unexpected error", err.Error())
+		t.Errorf("Unexpected error: %s", err.Error())
 	}
 	if got != want {
 		t.Errorf("want %v, got %v", want, got)
@@ -71,7 +71,7 @@ func TestGetValueWithEmptyDefault(t *testing.T) {
 	s := New()
 	got, err := s.GetValue("/db/user", "")
 	if err != nil {
-		t.Errorf("Unexpected error", err.Error())
+		t.Errorf("Unexpected error: %s", err.Error())
 	}
 	if got != want {
 		t.Errorf("want %v, got %v", want, got)


### PR DESCRIPTION
To fix failing tests I added the missing format directives to `t.Errorf` in these Test funcs:
 * TestGetValueWithDefault
 * TestGetValueWithEmptyDefault

environment:
 `go version go1.12.1 linux/amd64`
